### PR TITLE
[nicknamer]error message on double freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ readyPS.txt
 desktop.ini
 *.mo
 channeldashremover/
+.history/

--- a/nicknamer/nicknamer.py
+++ b/nicknamer/nicknamer.py
@@ -288,4 +288,3 @@ class NickNamer(commands.Cog):
         await ctx.send(
             _("Sending a DM set to {true_or_false}.").format(true_or_false=true_or_false)
         )
-

--- a/nicknamer/nicknamer.py
+++ b/nicknamer/nicknamer.py
@@ -167,6 +167,10 @@ class NickNamer(commands.Cog):
         reason: Optional[str] = "Nickname frozen.",
     ):
         """Freeze a users nickname."""
+        name_check = await self.config.guild(ctx.guild).frozen()
+        for id in name_check:
+            if user.id in id:
+                return await ctx.send("User is already frozen. Unfreeze them first.")
         try:
             await user.edit(nick=nickname)
             await ctx.tick()

--- a/nomic/__init__.py
+++ b/nomic/__init__.py
@@ -1,6 +1,7 @@
 from .nomic import NoMic
 
+
 async def setup(bot):
-    cog=NoMic(bot)
+    cog = NoMic(bot)
     await cog.initialize()
     bot.add_cog(cog)

--- a/nomic/nomic.py
+++ b/nomic/nomic.py
@@ -10,7 +10,7 @@ _ = Translator("nomic", __file__)
 class NoMic(commands.Cog):
     """#No-mic manager"""
 
-    def __init__(self,bot):
+    def __init__(self, bot):
         self.config = Config.get_conf(self, identifier=889, force_registration=True)
         default = {"channels": {}}
         self.config.register_global(**default)


### PR DESCRIPTION
quick fix for now. Returns error indicating user still has a frozen nickname and stops the adding of additional configurations if id is already in index.