### PR TITLE
[Roomer] Command Group Error

### DIFF
--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -336,13 +336,13 @@ class Roomer(commands.Cog):
         """Change settings for private text channels."""
         pass
 
-    @text.command(name="enable")
+    @tc.command(name="enable")
     async def tc_enable(self, ctx):
         """Enable private text channels."""
         await self.config.guild(ctx.guild).private_textchannels_enabled.set(True)
         await ctx.send(_("Private text channels enabled."))
 
-    @text.command(name="disable")
+    @tc.command(name="disable")
     async def tc_disable(self, ctx):
         """Enable private text channels."""
         await self.config.guild(ctx.guild).private_textchannels_enabled.set(False)

--- a/roomer/roomer.py
+++ b/roomer/roomer.py
@@ -331,18 +331,18 @@ class Roomer(commands.Cog):
 
     # region privatetc
 
-    @roomer.command()
+    @roomer.group()
     async def text(self, ctx):
         """Change settings for private text channels."""
         pass
 
-    @tc.command(name="enable")
+    @text.command(name="enable")
     async def tc_enable(self, ctx):
         """Enable private text channels."""
         await self.config.guild(ctx.guild).private_textchannels_enabled.set(True)
         await ctx.send(_("Private text channels enabled."))
 
-    @tc.command(name="disable")
+    @text.command(name="disable")
     async def tc_disable(self, ctx):
         """Enable private text channels."""
         await self.config.guild(ctx.guild).private_textchannels_enabled.set(False)


### PR DESCRIPTION
A user in cog support could not load `Roomer` due to the fact that `text` is not a command group.