### PR TITLE
Add streaming

### DIFF
--- a/botstatus/botstatus.py
+++ b/botstatus/botstatus.py
@@ -240,7 +240,7 @@ class Botstatus(commands.Cog):
     async def streaming(self, ctx, streamer: str, text: str):
         """
         Set a streaming status
-        Usage: [p]botstatus streaming <twitch url / username> <text>
+        Usage: [p]botstatus streaming <stream url> <text>
         """
         if len(text) > 128:
             await ctx.send(_("The character limit for status messages is 128."))


### PR DESCRIPTION
There is some things I wanna ask what you think is best approach.
It is now being used as 
[p]botstatus streaming online  lirik test
but as streamers are online by default maybe we should omit this or do you want to keep consistency here? 


Also thanks to Red and Axas for the majority of the code. 

Resolves #89 