### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/mcwhitelister/locales/messages.pot
+++ b/mcwhitelister/locales/messages.pot
@@ -30,7 +30,7 @@ msgid ""
 "        `port`: Your server's RCON port. (The default is 25575)\n"
 "        `password`: The RCON password.\n"
 "        RCON needs to be enabled and set up in your `server.properties` file.\n"
-"        More information is available [here](https://minecraft.fandom.com/wiki/Server.properties)\n"
+"        More information is available [here](https://minecraft.wiki/w/Server.properties)\n"
 "        "
 msgstr ""
 

--- a/mcwhitelister/locales/messages.pot
+++ b/mcwhitelister/locales/messages.pot
@@ -1,4 +1,4 @@
-a#
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/mcwhitelister/locales/messages.pot
+++ b/mcwhitelister/locales/messages.pot
@@ -1,4 +1,4 @@
-#
+a#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"

--- a/mcwhitelister/mcwhitelister.py
+++ b/mcwhitelister/mcwhitelister.py
@@ -73,7 +73,7 @@ class McWhitelister(commands.Cog):
         `port`: Your server's RCON port. (The default is 25575)
         `password`: The RCON password.
         RCON needs to be enabled and set up in your `server.properties` file.
-        More information is available [here](https://minecraft.fandom.com/wiki/Server.properties)
+        More information is available [here](https://minecraft.wiki/w/Server.properties)
         """
         await ctx.message.delete()
         await self.config.guild(ctx.guild).rcon.set((host, port, password))

--- a/mcwhitelister/mcwhitelister.py
+++ b/mcwhitelister/mcwhitelister.py
@@ -92,7 +92,11 @@ class McWhitelister(commands.Cog):
         """Add yourself to the whitelist."""
         p_in_conf = await self.config.guild(ctx.guild).players()
         if str(ctx.author.id) in p_in_conf:
-            await ctx.send(_("You are already whitelisted.\n Remove yourself first with {command}.").format(command=f"{ctx.clean_prefix}whitelister remove"))
+            await ctx.send(
+                _("You are already whitelisted.\n Remove yourself first with {command}.").format(
+                    command=f"{ctx.clean_prefix}whitelister remove"
+                )
+            )
             return
         host, port, passw = await self.config.guild(ctx.guild).rcon()
         p_in_conf[ctx.author.id] = {


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki