### PR TITLE
[Warnings] Use user instead of member parameter

### DIFF
--- a/check/check.py
+++ b/check/check.py
@@ -60,7 +60,7 @@ class Check(commands.Cog):
             await ctx.invoke(ctx.bot.get_command("read"), member=member.id)
         except:
             try:
-                await ctx.invoke(ctx.bot.get_command("warnings"), user=member)
+                await ctx.invoke(ctx.bot.get_command("warnings"), member=member.id)
             except:
                 self.log.debug("Command warn not found.")
 


### PR DESCRIPTION
In check/check.py and replace the line 63 to solve this.

// Original //
await ctx.invoke(ctx.bot.get_command("warnings"), user=member)

// New Line //
await ctx.invoke(ctx.bot.get_command("warnings"), member=member.id)